### PR TITLE
v2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.1.3
+
+- `DOMNode`:
+  - `buildHTML`: added parameter `buildTemplates = false`.
+- `TemplateNode`:
+  - `buildHTML`:
+    - respect `buildTemplates` parameter.
+    - pass `domContext` to `build` calls.
+- html: ^0.15.2
+- swiss_knife: ^3.1.3
+- lints: ^2.0.1
+- test: ^1.23.1
+- coverage: ^1.6.3
+
 ## 2.1.2
 
 - `$button`: Added `name` and `disabled`.
@@ -203,7 +217,7 @@
 
 - `DOMNodeRuntime`: Can manipulate CSS/style.
 - Added `DOMContext` and `Viewport` for `DOMGenerator`.
-- `CSS`: now is capable to convert viewport units to pixel units, based into [DOMContext] [Viewport].
+- `CSS`: now is capable to convert viewport units to pixel units, based into [DOMContext] and [Viewport].
 - Better `CSSLength`, `CSSBorder`, `CSSColorRGB`, `CSSColorHEX` and `CSSURL` parsing. 
 - swiss_knife: ^2.5.12
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/dom_builder.svg?logo=dart&logoColor=00b9fc)](https://pub.dartlang.org/packages/dom_builder)
 [![Null Safety](https://img.shields.io/badge/null-safety-brightgreen)](https://dart.dev/null-safety)
-[![CI](https://img.shields.io/github/workflow/status/gmpassos/dom_builder/Dart%20CI/master?logo=github-actions&logoColor=white)](https://github.com/gmpassos/dom_builder/actions)
+[![Dart CI](https://github.com/gmpassos/dom_builder/actions/workflows/dart.yml/badge.svg?branch=master)](https://github.com/gmpassos/dom_builder/actions/workflows/dart.yml)
 [![GitHub Tag](https://img.shields.io/github/v/tag/gmpassos/dom_builder?logo=git&logoColor=white)](https://github.com/gmpassos/dom_builder/releases)
 [![New Commits](https://img.shields.io/github/commits-since/gmpassos/dom_builder/latest?logo=git&logoColor=white)](https://github.com/gmpassos/dom_builder/network)
 [![Last Commits](https://img.shields.io/github/last-commit/gmpassos/dom_builder?logo=git&logoColor=white)](https://github.com/gmpassos/dom_builder/commits/master)

--- a/lib/src/dom_builder_attribute.dart
+++ b/lib/src/dom_builder_attribute.dart
@@ -314,7 +314,8 @@ class DOMAttributeValueTemplate extends DOMAttributeValueString {
       return super.getAttributeValue(domContext);
     } else {
       var build = template.build(domContext,
-          elementProvider: (q) => treeMap?.queryElement(q),
+          elementProvider: (q) => treeMap?.queryElement(q,
+              domContext: domContext, buildTemplates: true),
           intlMessageResolver: domContext.intlMessageResolver);
 
       if (build == null) {

--- a/lib/src/dom_builder_template.dart
+++ b/lib/src/dom_builder_template.dart
@@ -29,7 +29,7 @@ abstract class DOMTemplate {
     } else if (o is String) {
       return o;
     } else if (o is DOMNode) {
-      return o.buildHTML();
+      return o.buildHTML(buildTemplates: false);
     } else if (o is Iterable) {
       return o.map(objectToString).join('');
     } else if (o is Map) {
@@ -746,6 +746,8 @@ class DOMTemplateIntlMessage extends DOMTemplateNode {
     } else if (context is Map) {
       parameters =
           context.map((key, value) => MapEntry('$key', value as dynamic));
+    } else if (context is DOMContext) {
+      parameters = context.variables;
     }
 
     var s = intlMessageResolver(key, parameters);

--- a/lib/src/dom_builder_treemap.dart
+++ b/lib/src/dom_builder_treemap.dart
@@ -316,19 +316,21 @@ class DOMTreeMap<T> {
   }
 
   static final RegExp regexpTagRef =
-      RegExp(r'\{\{\s*([\w-]+|\*)\#([\w-]+)\s*\}\}');
+      RegExp(r'\{\{\s*([\w-]+|\*)#([\w-]+)\s*\}\}');
   static final RegExp regexpTagOpen =
       RegExp(r'''^\s*<[\w-]+\s(?:".*?"|'.*?'|\s+|[^>\s]+)*>''');
   static final RegExp regexpTagClose = RegExp(r'''<\/[\w-]+\s*>\s*$''');
 
-  String? queryElement(String query) {
+  String? queryElement(String query,
+      {DOMContext? domContext, bool buildTemplates = false}) {
     if (isEmptyString(query)) return null;
 
     var rootDOMNode = this.rootDOMNode as DOMElement;
 
     var node = rootDOMNode.select(query)!;
 
-    var html = node.buildHTML();
+    var html =
+        node.buildHTML(domContext: domContext, buildTemplates: buildTemplates);
 
     html = html.replaceFirst(regexpTagOpen, '');
     html = html.replaceFirst(regexpTagClose, '');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,21 +1,21 @@
 name: dom_builder
 description: Generate and manipulate DOM elements (virtual or real), DSX (like JSX) and HTML declarations (Web and Native support).
-version: 2.1.2
+version: 2.1.3
 homepage: https://github.com/gmpassos/dom_builder
 
 environment:
   sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
-  html: ^0.15.0
-  swiss_knife: ^3.1.1
+  html: ^0.15.2
+  swiss_knife: ^3.1.3
   collection: ^1.17.0
 
 dev_dependencies:
-  lints: ^2.0.0
-  test: ^1.17.10
+  lints: ^2.0.1
+  test: ^1.23.1
   dependency_validator: ^3.2.2
-  coverage: ^1.5.0
+  coverage: ^1.6.3
 
 #dependency_overrides:
 #  swiss_knife:

--- a/test/dom_builder_template_test.dart
+++ b/test/dom_builder_template_test.dart
@@ -546,17 +546,35 @@ void main() {
 
       expect(clicks, isEmpty);
 
-      var context = DOMContext(
+      var contextAM = DOMContext(
           intlMessageResolver: (k, [p]) => k.trim().toUpperCase(),
           variables: {'period': 'am'});
 
-      var source2 = div.buildHTML(domContext: context);
+      var contextPM = DOMContext(
+          intlMessageResolver: (k, [p]) => k.trim().toUpperCase(),
+          variables: {'period': 'pm'});
+
+      var source2 = div.buildHTML(domContext: contextAM);
 
       expectFilteredDSXFunction(
         source2,
         '<div title="HI" onclick="{{__DSX__function_D}}">'
         '{{:period=="am"}}<b>morning</b>{{?:period=="pm"}}afternoon{{?}}day{{/}}'
         '</div>',
+      );
+
+      var source3 = div.buildHTML(domContext: contextAM, buildTemplates: true);
+
+      expectFilteredDSXFunction(
+        source3,
+        '<div title="HI" onclick="{{__DSX__function_D}}"><b>morning</b></div>',
+      );
+
+      var source4 = div.buildHTML(domContext: contextPM, buildTemplates: true);
+
+      expectFilteredDSXFunction(
+        source4,
+        '<div title="HI" onclick="{{__DSX__function_D}}">afternoon</div>',
       );
 
       expect(clicks, isEmpty);


### PR DESCRIPTION
- `DOMNode`:
  - `buildHTML`: added parameter `buildTemplates = false`.
- `TemplateNode`:
  - `buildHTML`: - respect `buildTemplates` parameter. - pass `domContext` to `build` calls.
- html: ^0.15.2
- swiss_knife: ^3.1.3
- lints: ^2.0.1
- test: ^1.23.1
- coverage: ^1.6.3