### PR TITLE
v2.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 2.1.8
+
+- Optimize:
+  - `DOMAttribute.from`:
+    - Check `DOMTemplate.possiblyATemplate` before call `DOMTemplate.parse`.
+  - `DOMTemplate`:
+    - `possiblyATemplate` and `_parse`: check for minimal template length.
+  - `DOMNode`:
+    - `from`, `parseNodes` and `_parseNode`: optimize `Iterable` nodes resolution.
+    - `_addListToContent` and `__insertListToContent`: Avoid input list copy.
+  - `DOMElement`:
+    - Field `tag`:
+      - Changed to NOT null.
+      - Always lower-case.
+- html: ^0.15.3
+
 ## 2.1.7
 
 - Added `CSSFunction` (extends `CSSValues`):

--- a/lib/src/dom_builder_attribute.dart
+++ b/lib/src/dom_builder_attribute.dart
@@ -68,7 +68,7 @@ class DOMAttribute implements WithValue {
     name = normalizeName(name);
     if (name == null) return null;
 
-    if (value is String) {
+    if (value is String && DOMTemplate.possiblyATemplate(value)) {
       var template = DOMTemplate.parse(value);
       if (!template.hasOnlyContent) {
         return DOMAttribute(name, DOMAttributeValueTemplate(value));

--- a/lib/src/dom_builder_generator.dart
+++ b/lib/src/dom_builder_generator.dart
@@ -826,7 +826,7 @@ abstract class DOMGenerator<T> {
   T? createWithRegisteredElementGenerator(DOMElement? domParent, T? parent,
       DOMElement domElement, DOMTreeMap<T> treeMap, DOMContext<T>? context) {
     var tag = domElement.tag;
-    var generator = _elementsGenerators[tag!];
+    var generator = _elementsGenerators[tag];
     if (generator == null) return null;
 
     T? contentHolder;
@@ -875,7 +875,8 @@ abstract class DOMGenerator<T> {
   static String? normalizeTag(String? tag) {
     if (tag == null) return null;
     tag = tag.toLowerCase().trim();
-    return tag.isNotEmpty ? tag : null;
+    if (tag.isEmpty) return null;
+    return tag;
   }
 
   bool registerElementGeneratorFrom(DOMGenerator<T> otherGenerator) {

--- a/lib/src/dom_builder_generator_dart_html.dart
+++ b/lib/src/dom_builder_generator_dart_html.dart
@@ -80,8 +80,7 @@ class DOMGeneratorDartHTMLImpl extends DOMGeneratorDartHTML<Node> {
     if (node is Text) {
       return domNode is TextNode;
     } else if (node is Element) {
-      return domNode is DOMElement &&
-          domNode.tag!.toLowerCase() == node.tagName.toLowerCase();
+      return domNode is DOMElement && domNode.tag == node.tagName.toLowerCase();
     }
     return false;
   }

--- a/lib/src/dom_builder_template.dart
+++ b/lib/src/dom_builder_template.dart
@@ -96,8 +96,9 @@ abstract class DOMTemplate {
 
   static DOMTemplateNode? _parse(String? s, bool tryParsing) {
     if (s == null) {
-      if (tryParsing) return null;
-      return DOMTemplateNode([]);
+      // Only `tryParse` can pass a `null` [s].
+      assert(tryParsing);
+      return null;
     }
 
     if (s.length < _templateMinimalLength) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: dom_builder
 description: Generate and manipulate DOM elements (virtual or real), DSX (like JSX) and HTML declarations (Web and Native support).
-version: 2.1.7
+version: 2.1.8
 homepage: https://github.com/gmpassos/dom_builder
 
 environment:
   sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
-  html: ^0.15.2
+  html: ^0.15.3
   swiss_knife: ^3.1.5
   collection: ^1.17.0
 

--- a/test/dom_builder_template_test.dart
+++ b/test/dom_builder_template_test.dart
@@ -473,6 +473,7 @@ void main() {
     test('tryParse', () {
       var source1 = 'Hello! Period: {{:period!=hourPeriod}}diff{{?}}eq{{/}}!';
       var source2 = 'Hello! Period: {{:period!=hourPeriod}}diff{{?}}eq!';
+      var source3 = '{{x}}';
 
       var template1 = DOMTemplate.tryParse(source1)!;
       expect(template1.nodes.length, equals(3));
@@ -480,6 +481,29 @@ void main() {
 
       var template2 = DOMTemplate.tryParse(source2);
       expect(template2, isNull);
+
+      var template3 = DOMTemplate.tryParse(source3)!;
+      expect(template3.nodes.length, equals(1));
+      expect(template3.toString(), equals('{{x}}'));
+
+      expect(DOMTemplate.tryParse(''), isNull);
+      expect(DOMTemplate.tryParse('x'), isNull);
+
+      expect(DOMTemplate.tryParse('{{}}'), isNull);
+    });
+
+    test('parse empty', () {
+      var template1 = DOMTemplate.parse('');
+      expect(template1.nodes.length, equals(1));
+      expect(template1.toString(), equals(''));
+
+      var template2 = DOMTemplate.parse(' ');
+      expect(template2.nodes.length, equals(1));
+      expect(template2.toString(), equals(' '));
+
+      var template3 = DOMTemplate.parse('{{}}');
+      expect(template3.nodes.length, equals(0));
+      expect(template3.toString(), equals(''));
     });
 
     test('intl:hi', () {

--- a/test/dom_builder_template_test.dart
+++ b/test/dom_builder_template_test.dart
@@ -482,6 +482,8 @@ void main() {
       var template2 = DOMTemplate.tryParse(source2);
       expect(template2, isNull);
 
+      expect(() => DOMTemplate.parse(source2), throwsA(isA<StateError>()));
+
       var template3 = DOMTemplate.tryParse(source3)!;
       expect(template3.nodes.length, equals(1));
       expect(template3.toString(), equals('{{x}}'));
@@ -504,6 +506,11 @@ void main() {
       var template3 = DOMTemplate.parse('{{}}');
       expect(template3.nodes.length, equals(0));
       expect(template3.toString(), equals(''));
+
+      var template4 = DOMTemplate.parse('Hello World');
+      expect(template4.nodes.length, equals(1));
+      expect(template4.hasOnlyContent, isTrue);
+      expect(template4.toString(), equals('Hello World'));
     });
 
     test('intl:hi', () {


### PR DESCRIPTION
- Optimize:
  - `DOMAttribute.from`: - Check `DOMTemplate.possiblyATemplate` before call `DOMTemplate.parse`.
  - `DOMTemplate`:
    - `possiblyATemplate` and `_parse`: check for minimal template length.
  - `DOMNode`: - `from`, `parseNodes` and `_parseNode`: optimize `Iterable` nodes resolution. - `_addListToContent` and `__insertListToContent`: Avoid input list copy.
  - `DOMElement`:
    - Field `tag`: - Changed to NOT null. - Always lower-case.
- html: ^0.15.3