### PR TITLE
v3.0.1 - Refactor: update cancel subscriptions behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 3.0.1
+
+- `DOMElement`:
+  - Added getter `hasAnyEventListener` to check if any event callback is attached.
+  - Added method `closeAllEventListeners` to asynchronously close and remove all attached event listeners.
+
+- `DOMTreeMap`:
+  - Added method `mapTree` to map a DOM subtree to a component tree, returning whether mapping was created or updated.
+  - Added method `domElementsWithEventListener` to return all mapped `DOMElement`s with event listeners.
+  - Added method `mapSubscriptions` to register subscriptions associated with a node for later cancellation.
+  - Added method `elementsWithSubscriptions` to return elements that have active subscriptions.
+  - Added method `getSubscriptions` to return subscriptions registered for a node.
+  - Updated `cancelSubscriptions` to cancel and remove all subscriptions registered for a node.
+  - Updated `cancelAllSubscriptions` to optionally cancel element subscriptions and/or close DOM event listeners attached to elements.
+
+- `DOMTreeMapDummy`:
+  - Updated `cancelAllSubscriptions` signature to match `DOMTreeMap` with optional parameters for subscription and event listener cancellation.
+
 ## 3.0.0
 
 - `DOMGenerator`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,10 @@
   - Added method `closeAllEventListeners` to asynchronously close and remove all attached event listeners.
 
 - `DOMTreeMap`:
-  - Added method `mapTree` to map a DOM subtree to a component tree, returning whether mapping was created or updated.
+  - Added method documentation:
+    - `mapTree`, `mapSubscriptions`, `elementsWithSubscriptions`, `getSubscriptions`, `cancelSubscriptions`, `cancelAllSubscriptions`.
   - Added method `domElementsWithEventListener` to return all mapped `DOMElement`s with event listeners.
-  - Added method `mapSubscriptions` to register subscriptions associated with a node for later cancellation.
-  - Added method `elementsWithSubscriptions` to return elements that have active subscriptions.
-  - Added method `getSubscriptions` to return subscriptions registered for a node.
-  - Updated `cancelSubscriptions` to cancel and remove all subscriptions registered for a node.
-  - Updated `cancelAllSubscriptions` to optionally cancel element subscriptions and/or close DOM event listeners attached to elements.
+  - Updated cancelAllSubscriptions to optionally cancel element subscriptions and/or close DOM event listeners attached to elements.
 
 - `DOMTreeMapDummy`:
   - Updated `cancelAllSubscriptions` signature to match `DOMTreeMap` with optional parameters for subscription and event listener cancellation.

--- a/lib/src/dom_builder_base.dart
+++ b/lib/src/dom_builder_base.dart
@@ -2751,6 +2751,92 @@ class DOMElement extends DOMNode with WithValue implements AsDOMElement {
         attributes: attributes, commented: isCommented, content: copyContent());
   }
 
+  /// True when at least one event callback is attached.
+  ///
+  /// See [onClick], [onChange], [onKeyPress], [onKeyUp], [onKeyDown],
+  /// [onMouseOver], [onMouseOut], [onLoad], [onError], [onGenerate].
+  bool get hasAnyEventListener =>
+      _onClick != null ||
+      _onChange != null ||
+      _onKeyPress != null ||
+      _onKeyUp != null ||
+      _onKeyDown != null ||
+      _onMouseOver != null ||
+      _onMouseOut != null ||
+      _onLoad != null ||
+      _onError != null ||
+      _onGenerate != null;
+
+  /// Closes and removes all attached event listeners.
+  ///
+  /// Awaits each listener disposal to ensure no pending callbacks
+  /// remain after the component is torn down.
+  Future<int> closeAllEventListeners() async {
+    var closeCount = 0;
+
+    if (_onClick != null) {
+      await _onClick!.close();
+      _onClick = null;
+      ++closeCount;
+    }
+
+    if (_onChange != null) {
+      await _onChange!.close();
+      _onChange = null;
+      ++closeCount;
+    }
+
+    if (_onKeyPress != null) {
+      await _onKeyPress!.close();
+      _onKeyPress = null;
+      ++closeCount;
+    }
+
+    if (_onKeyUp != null) {
+      await _onKeyUp!.close();
+      _onKeyUp = null;
+      ++closeCount;
+    }
+
+    if (_onKeyDown != null) {
+      await _onKeyDown!.close();
+      _onKeyDown = null;
+      ++closeCount;
+    }
+
+    if (_onMouseOver != null) {
+      await _onMouseOver!.close();
+      _onMouseOver = null;
+      ++closeCount;
+    }
+
+    if (_onMouseOut != null) {
+      await _onMouseOut!.close();
+      _onMouseOut = null;
+      ++closeCount;
+    }
+
+    if (_onLoad != null) {
+      await _onLoad!.close();
+      _onLoad = null;
+      ++closeCount;
+    }
+
+    if (_onError != null) {
+      await _onError!.close();
+      _onError = null;
+      ++closeCount;
+    }
+
+    if (_onGenerate != null) {
+      await _onGenerate!.close();
+      _onGenerate = null;
+      ++closeCount;
+    }
+
+    return closeCount;
+  }
+
   EventStream<DOMMouseEvent>? _onClick;
 
   /// Returns [true] if has any [onClick] listener registered.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dom_builder
 description: Generate and manipulate DOM elements (virtual or real), DSX (like JSX) and HTML declarations (Web and Native support).
-version: 3.0.0
+version: 3.0.1
 homepage: https://github.com/gmpassos/dom_builder
 
 environment:

--- a/test/dom_event_listener_test.dart
+++ b/test/dom_event_listener_test.dart
@@ -1,0 +1,148 @@
+import 'dart:async';
+
+import 'package:dom_builder/dom_builder.dart';
+import 'package:test/test.dart';
+
+import 'dom_builder_domtest.dart';
+
+void main() {
+  group('DOMElement.hasAnyEventListener', () {
+    test('false when no listeners', () {
+      final el = $div();
+      expect(el.hasAnyEventListener, isFalse);
+    });
+
+    test('true after adding click listener', () {
+      final el = $div();
+      el.onClick.listen((_) {});
+      expect(el.hasAnyEventListener, isTrue);
+    });
+
+    test('true with multiple listeners', () {
+      final el = $input();
+      el.onChange.listen((_) {});
+      el.onKeyDown.listen((_) {});
+      expect(el.hasAnyEventListener, isTrue);
+    });
+  });
+
+  group('DOMElement.closeAllEventListeners', () {
+    test('returns 0 when none', () async {
+      final el = $div();
+      final closed = await el.closeAllEventListeners();
+      expect(closed, 0);
+      expect(el.hasAnyEventListener, isFalse);
+    });
+
+    test('closes single listener', () async {
+      final el = $div();
+      el.onClick.listen((_) {});
+      expect(el.hasAnyEventListener, isTrue);
+
+      final closed = await el.closeAllEventListeners();
+
+      expect(closed, 1);
+      expect(el.hasAnyEventListener, isFalse);
+    });
+
+    test('closes all listeners', () async {
+      final el = $input();
+      el.onClick.listen((_) {});
+      el.onChange.listen((_) {});
+      el.onKeyDown.listen((_) {});
+      el.onKeyUp.listen((_) {});
+      el.onKeyPress.listen((_) {});
+      el.onMouseOver.listen((_) {});
+      el.onMouseOut.listen((_) {});
+
+      expect(el.hasAnyEventListener, isTrue);
+
+      final closed = await el.closeAllEventListeners();
+
+      expect(closed, greaterThanOrEqualTo(7));
+      expect(el.hasAnyEventListener, isFalse);
+    });
+  });
+
+  group('DOMTreeMap.domElementsWithEventListener', () {
+    test('returns only elements with listeners', () {
+      final generator = TestGenerator();
+      final tree = DOMTreeMap<TestNode>(generator);
+
+      final a = $div();
+      final b = $div();
+      final c = $div();
+
+      a.onClick.listen((_) {});
+      c.onMouseOver.listen((_) {});
+
+      var aDiv = a.buildDOM(generator: generator)!;
+      var bDiv = b.buildDOM(generator: generator)!;
+      var cDiv = c.buildDOM(generator: generator)!;
+
+      tree.map(a, aDiv);
+      tree.map(b, bDiv);
+      tree.map(c, cDiv);
+
+      final list = tree.domElementsWithEventListener();
+
+      expect(list, containsAll([a, c]));
+      expect(list, isNot(contains(b)));
+    });
+  });
+
+  group('DOMTreeMap.cancelAllSubscriptions flags', () {
+    test('does not close listeners when disabled', () async {
+      final generator = TestGenerator();
+      final tree = DOMTreeMap<TestNode>(generator);
+
+      final el = $div();
+
+      el.onClick.listen((_) {});
+
+      var elDiv = el.buildDOM(generator: generator)!;
+      tree.map(el, elDiv);
+
+      tree.cancelAllSubscriptions(
+        elementsSubscriptions: true,
+        domElementsEventListeners: false,
+      );
+
+      expect(el.hasAnyEventListener, isTrue);
+    });
+
+    test('closes listeners when enabled', () async {
+      final generator = TestGenerator();
+      final tree = DOMTreeMap<TestNode>(generator);
+
+      final el = $div();
+
+      el.onClick.listen((_) {});
+
+      var elDiv = el.buildDOM(generator: generator)!;
+      tree.map(el, elDiv);
+
+      tree.cancelAllSubscriptions();
+
+      // allow async close
+      await Future.delayed(Duration(milliseconds: 1));
+
+      expect(el.hasAnyEventListener, isFalse);
+    });
+  });
+
+  group('DOMTreeMap element subscriptions unaffected', () {
+    test('cancel only element subscriptions', () async {
+      final generator = TestGenerator();
+      final tree = DOMTreeMap<TestNode>(generator);
+      final node = TestElem('div');
+
+      final sub = StreamController().stream.listen((_) {});
+      tree.mapSubscriptions(node, [sub]);
+
+      tree.cancelAllSubscriptions(domElementsEventListeners: false);
+
+      expect(tree.getSubscriptions(node), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION

- `DOMElement`:
  - Added getter `hasAnyEventListener` to check if any event callback is attached.
  - Added method `closeAllEventListeners` to asynchronously close and remove all attached event listeners.

- `DOMTreeMap`:
  - Added method documentation:
    - `mapTree`, `mapSubscriptions`, `elementsWithSubscriptions`, `getSubscriptions`, `cancelSubscriptions`, `cancelAllSubscriptions`.
  - Added method `domElementsWithEventListener` to return all mapped `DOMElement`s with event listeners.
  - Updated cancelAllSubscriptions to optionally cancel element subscriptions and/or close DOM event listeners attached to elements.

- `DOMTreeMapDummy`:
  - Updated `cancelAllSubscriptions` signature to match `DOMTreeMap` with optional parameters for subscription and event listener cancellation.
