### PR TITLE
v3.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 - `DOMContext`:
   - `copy`: fixed copying of `_domGenerator` field by assigning `_domGenerator` instead of `domGenerator`.
 
+- `dom_builder_dsx.dart`:
+  - `_dsxJoinStrings`:
+    - updated parameter type to `List<Object?>`.
+    - fixed `list.remove(i)` to `list.removeAt(i)` to correctly remove element by index.
+
+- `dom_builder_template.dart`:
+  - `DOMTemplateVariable`:
+    - Improved index bounds check to ensure `idx` is non-negative before accessing `context` list elements.
+
 ## 3.0.6
 
 - `DOMElement`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - `DOMContext`:
   - `copy`: fixed copying of `_domGenerator` field by assigning `_domGenerator` instead of `domGenerator`.
+  - `resolveViewportCSSLength`: added local variable `viewport` to avoid repeated null checks.
+  - `_computeViewportCSSLength`: changed parameter `viewport` from nullable to non-nullable and removed redundant null assertions.
+
+- `DOMGeneratorWebImpl`:
+  - Fixed incorrect variable usage in `addExternalElementToElement` loop by replacing `externalElement.asJSAny` with `e.asJSAny`.
 
 - `dom_builder_dsx.dart`:
   - `_dsxJoinStrings`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.7
+
+- `DOMContext`:
+  - `copy`: fixed copying of `_domGenerator` field by assigning `_domGenerator` instead of `domGenerator`.
+
 ## 3.0.6
 
 - `DOMElement`:

--- a/lib/src/dom_builder_context.dart
+++ b/lib/src/dom_builder_context.dart
@@ -134,7 +134,7 @@ class DOMContext<T extends Object> {
         parent: parent,
         viewport: viewport,
         resolveCSSViewportUnit: resolveCSSViewportUnit);
-    context.domGenerator = domGenerator;
+    context._domGenerator = _domGenerator;
     context.namedElementAttribute = namedElementAttribute;
     context.namedElementProvider = namedElementProvider;
     context.variables = Map.from(deepCopy(variables)!);
@@ -282,7 +282,8 @@ class DOMContext<T extends Object> {
   Map<String, dynamic>? _variables;
 
   Map<String, dynamic> get variables {
-    var vars = parent != null ? parent!.variables : <String, dynamic>{};
+    final parent = this.parent;
+    var vars = parent != null ? parent.variables : <String, dynamic>{};
 
     if (_variables != null) {
       vars.addAll(_variables!);

--- a/lib/src/dom_builder_context.dart
+++ b/lib/src/dom_builder_context.dart
@@ -199,27 +199,29 @@ class DOMContext<T extends Object> {
   }
 
   CSSLength resolveViewportCSSLength(num value, CSSUnit unit) {
+    final viewport = this.viewport;
     if (viewport == null) {
       return CSSLength(value, unit);
     }
+
     var resolvedViewportValue =
         _computeViewportCSSLength(value, unit, viewport);
     return resolvedViewportValue ?? CSSLength(value, unit);
   }
 
   CSSLength? _computeViewportCSSLength(
-      num value, CSSUnit unit, Viewport? viewport) {
+      num value, CSSUnit unit, Viewport viewport) {
     var ratio = value / 100;
 
     switch (unit) {
       case CSSUnit.vw:
-        return CSSLength(ratio * viewport!.width);
+        return CSSLength(ratio * viewport.width);
       case CSSUnit.vh:
-        return CSSLength(ratio * viewport!.height);
+        return CSSLength(ratio * viewport.height);
       case CSSUnit.vmin:
-        return CSSLength(ratio * viewport!.vmin);
+        return CSSLength(ratio * viewport.vmin);
       case CSSUnit.vmax:
-        return CSSLength(ratio * viewport!.vmax);
+        return CSSLength(ratio * viewport.vmax);
       default:
         return null;
     }

--- a/lib/src/dom_builder_dsx.dart
+++ b/lib/src/dom_builder_dsx.dart
@@ -697,7 +697,7 @@ List _dsxToList(dynamic o) {
   }
 }
 
-void _dsxJoinStrings(List list) {
+void _dsxJoinStrings(List<Object?> list) {
   for (var i = 1; i < list.length;) {
     var prev = list[i - 1];
     var elem = list[i];
@@ -705,7 +705,7 @@ void _dsxJoinStrings(List list) {
     if (elem is String && prev is String) {
       var s = prev + elem;
       list[i - 1] = s;
-      list.remove(i);
+      list.removeAt(i);
     } else {
       ++i;
     }

--- a/lib/src/dom_builder_generator_web.dart
+++ b/lib/src/dom_builder_generator_web.dart
@@ -276,7 +276,7 @@ class DOMGeneratorWebImpl extends DOMGeneratorWeb<Node> {
             added.addAll(l);
           }
         } else {
-          var jsAny = externalElement.asJSAny;
+          var jsAny = e.asJSAny;
           if (jsAny.isA<Node>()) {
             var node = jsAny as Node;
             element.appendChild(node);

--- a/lib/src/dom_builder_runtime.dart
+++ b/lib/src/dom_builder_runtime.dart
@@ -299,7 +299,11 @@ abstract class DOMNodeRuntime<T extends Object> {
     remove();
 
     var idxUp = parentRuntime!._contentFromIndexBackwardWhere(
-        idx - 1, 0, (node) => domGenerator.isElementNode(node));
+      idx - 1,
+      0,
+      (node) => domGenerator.isElementNode(node),
+    );
+
     if (idxUp < 0) {
       idxUp = 0;
     }

--- a/lib/src/dom_builder_template.dart
+++ b/lib/src/dom_builder_template.dart
@@ -565,7 +565,7 @@ class DOMTemplateVariable {
         }
       }
       if (idx != null) {
-        return idx < context.length ? context[idx] : null;
+        return idx >= 0 && idx < context.length ? context[idx] : null;
       }
     } else if (context is Set) {
       if (context.contains(key)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dom_builder
 description: Generate and manipulate DOM elements (virtual or real), DSX (like JSX) and HTML declarations (Web and Native support).
-version: 3.0.6
+version: 3.0.7
 homepage: https://github.com/gmpassos/dom_builder
 
 environment:


### PR DESCRIPTION
- `DOMContext`:
  - `copy`: fixed copying of `_domGenerator` field by assigning `_domGenerator` instead of `domGenerator`.